### PR TITLE
Remove Svelte reactive $, because mobx already reacts.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,9 +9,10 @@
     let currentTimeString;
     let elapsedSecondsString;
 
-    $: autorun(() => {
+    autorun(() => {
         currentTimeString = vm.currentTimeString;
         elapsedSecondsString = vm.elapsedSecondsString;
+        console.log("AUTORUN executed for elapsed time: "+ elapsedSecondsString);
     });
 </script>
 

--- a/src/App.vm.ts
+++ b/src/App.vm.ts
@@ -1,7 +1,7 @@
 import { makeAutoObservable, observable, computed, action } from "mobx";
 import { timeFormatter } from "./utils";
 
-const UPDATE_INTERVAL = 250;
+const UPDATE_INTERVAL = 1000;
 
 export class AppVm {
     startTime: Date = new Date();


### PR DESCRIPTION
The original example always executes the reactive part twice, which is one time too much.  Once as a result of mobx, and once as a result of the Svelte reactive statement. 
In this branch the Svelte reactive $: has been removed, and now the reactive statements are executed only once.
To see this, add the $: again, and see in the console that this console message always appears twice instead of once.